### PR TITLE
Fix multipart upload of large files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-_There are no unreleased changes at the moment._
+### Fixed
+
+* Fix upload of large files to MinIO.
 
 ## [2.0.1] - 2021-01-13
 

--- a/cs_api_core/cs_api_core.ml
+++ b/cs_api_core/cs_api_core.ml
@@ -86,8 +86,7 @@ let build_file_upload_request ~s3_url ~s3_signature ~(file : Api.File.t) =
   { Api.Request.url = s3_url
   ; header = []
   ; method_ = Post
-  ; data = Multipart (direct_fields @ [{name = "trace"; content = File file}])
-  }
+  ; data = Multipart (direct_fields @ [{name = "file"; content = File file}]) }
 
 let build_trace_import_request ~api ~project_id ~s3_key ~trace_name ~file =
   let {Api.endpoint; key} = api in

--- a/cs_api_io/cs_api_io.ml
+++ b/cs_api_io/cs_api_io.ml
@@ -15,12 +15,13 @@ let response_accumulator_factory () =
 let set_headers curl header =
   Curl.set_httpheader curl (List.map (fun (h, v) -> h ^ ": " ^ v) header)
 
-let set_part {Api.Part.name; content} =
+let make_part {Api.Part.name; content} =
   match content with
-  | Direct s -> Curl.CURLFORM_CONTENT (name, s, Curl.DEFAULT)
-  | File {path; _} -> Curl.CURLFORM_FILECONTENT ("file", path, Curl.DEFAULT)
+  | Direct s -> Curl.CURLFORM_CONTENT (name, s, DEFAULT)
+  | File {path; _} -> Curl.CURLFORM_FILE (name, path, DEFAULT)
 
-let set_multipart curl parts = List.map set_part parts |> Curl.set_httppost curl
+let set_multipart curl parts =
+  parts |> List.map make_part |> Curl.set_httppost curl
 
 let send_request_exn ~verify {Api.Request.url; header; method_; data} =
   Curl.global_init Curl.CURLINIT_GLOBALALL;

--- a/test/test.ml
+++ b/test/test.ml
@@ -32,7 +32,7 @@ let request_builder_tests =
                   ; ("signature", "cde")
                   ; ("Content-Type", "")
                   ; ("x-amz-meta-filename", "path") ]
-              @ [ { name = "trace"
+              @ [ { name = "file"
                   ; content = File {path = "folder/path"; size = 10} } ] ) }
       ~actual:
         (Cs_api_core.build_file_upload_request ~s3_url:"url"


### PR DESCRIPTION
This uses the `CURLFORM_FILE` option instead of `CURLFORM_FILECONTENT`. This makes the field a real file upload field.  Indeed, according to the documentation of `CURLFORM_FILECONTENT` (https://curl.se/libcurl/c/curl_formadd.html#CURLFORMFILECONTENT):

> This part does not automatically become a file upload part simply because its data was read from a file.

The change is visible in the multipart form data.  We now have:

    Content-Disposition: form-data; name="file"; filename="trace.cst.gz"
    Content-Type: application/octet-stream

instead of just:

    Content-Disposition: form-data; name="file"

I think this makes MinIO treat this part as the uploaded file, which avoids the file size error.

I managed to achieve the same result with the `curl_mime_*` functions, which are supposed to replace `curl_form*`.  Unfortunately, this new API is only available for libcurl 7.56 and above, which makes it unsuitable for our use case where CentOS 7, with libcurl 7.29, is a common environment.