### PR TITLE
Allow the user to provide a project name

### DIFF
--- a/cs_api_core/cs_api_core.mli
+++ b/cs_api_core/cs_api_core.mli
@@ -13,6 +13,10 @@ val parse_s3_response : body:string -> string
 val build_s3_signed_post_request : api:Api.t -> Api.Request.t
 (** Request building functions **)
 
+val build_list_projects_request : api:Api.t -> Api.Request.t
+
+val parse_list_projects_response : body:string -> (string * int) list
+
 val build_file_upload_request :
      s3_url:string
   -> s3_signature:Api.S3Signature.t


### PR DESCRIPTION
A project name can now be given instead of a project ID. The new option is `--project-name` and is mutually exclusive with `--project-id`.

Currently, since our API lacks a way to get a `Project` by name directly, the tool downloads the full list of project IDs and names to determine which one matches the user-provided name.