### PR TITLE
Add `--ca-file` CLI option to choose trusted CAs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ In the web interface, select your project by clicking it and copy the number aft
 
 Use the `--api-base-url` parameter to point the CLI at your local instance.
 
-If you are using self-signed certificates and want to upload anyway, use the
-`--no-check-certificate` option.
+If you are using self-signed certificates or a custom CA, you can provide a custom CA file
+with the `--ca-file path/to/cabundle.pem` option.
 
 #### HTTP Proxies
 

--- a/cs_api_client.opam
+++ b/cs_api_client.opam
@@ -21,7 +21,7 @@ depends: [
   "lwt"
   "lwt_ppx"
   "lwt_ssl"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.13.0"}
   "ocamlformat" {= "0.19.0" & with-test}
   "ocurl" {< "0.9.2"}  # For compilation with old libcurl
   "ppx_deriving"

--- a/cs_api_io/cs_api_io.mli
+++ b/cs_api_io/cs_api_io.mli
@@ -1,8 +1,14 @@
+module Config : sig
+  type t =
+    { verify : bool
+    ; ca_file : string option }
+end
+
 module Response : sig
   type t
 end
 
 val send_request :
-  ?verify:bool -> Api.Request.t -> (Response.t, string) result Lwt.t
+  config:Config.t -> Api.Request.t -> (Response.t, string) result Lwt.t
 
 val get_response : Response.t -> (string, string) result Lwt.t


### PR DESCRIPTION
This should be useful for on-premises users and also on Windows where, as far as I could tell, it's hard to have libcurl use the right CA file by default.