### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        if: runner.os != 'Windows'
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        if: runner.os == 'Windows'
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            default: 'https://github.com/fdopen/opam-repository-mingw.git#opam2'
+            upstream: 'https://github.com/ocaml/opam-repository.git'
       - run: opam pin add cs_api_client.dev . --no-action
       - run: opam depext cs_api_client --yes --with-test
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
+          - windows-latest
         ocaml-compiler:
           - 4.13.x
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add cs_api_client.dev . --no-action
-      - run: opam depext cs_api_client --yes --with-doc --with-test
-      - run: opam install . --deps-only --with-doc --with-test
+      - run: opam depext cs_api_client --yes --with-test
+      - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @all @fmt @runtest

--- a/cs_api_client.opam
+++ b/cs_api_client.opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving"
   "ssl" {= "0.5.9"}  # For compilation with OpenSSL < 1.1.0
   "stringext"
-  "terminal_size"
+  "terminal_size" {>= "0.2.0"}  # For compilation on Windows
   "tls"
   "yojson"
 ]


### PR DESCRIPTION
For now we don't produce any artifact in CI, so the binaries have to be uploaded to each release manually. Hopefully we'll fix that in the future.

For more information on OCaml and Windows, see https://www.ocaml.org/platform/ocaml_on_windows.html.