### PR TITLE
Initialize and clean up libcurl just once

### DIFF
--- a/cs_api_io/cs_api_io.mli
+++ b/cs_api_io/cs_api_io.mli
@@ -8,7 +8,16 @@ module Response : sig
   type t
 end
 
+type t
+
+val with_client : config:Config.t -> f:(t -> 'a) -> 'a
+(** Initialize the client and clean up after the provided function [f] has been executed.
+
+    This currently uses libcurl. The library must have been globally initalized before
+    this wrapper is called. Cleanup of the "easy" session is guaranteed even if the
+    provided function [f] raises an exception. *)
+
 val send_request :
-  config:Config.t -> Api.Request.t -> (Response.t, string) result Lwt.t
+  client:t -> Api.Request.t -> (Response.t, string) result Lwt.t
 
 val get_response : Response.t -> (string, string) result Lwt.t


### PR DESCRIPTION
This reuses the easy session between requests instead of creating a new one every time. This is cleaner and will hopefully fix a memory error encountered in the previous version.