### PR TITLE
Clean up dependencies

### DIFF
--- a/cs_api_client.opam
+++ b/cs_api_client.opam
@@ -17,18 +17,13 @@ depends: [
   "cmdliner" {= "1.0.4"}
   "containers" {>= "3.6"}
   "dune" {>= "2.7.0"}
-  "hacl_x25519" {< "0.2.0"}
   "lwt"
   "lwt_ppx"
-  "lwt_ssl"
   "ocaml" {>= "4.13.0"}
   "ocamlformat" {= "0.19.0" & with-test}
   "ocurl" {< "0.9.2"}  # For compilation with old libcurl
   "ppx_deriving"
-  "ssl" {= "0.5.9"}  # For compilation with OpenSSL < 1.1.0
-  "stringext"
   "terminal_size" {>= "0.2.0"}  # For compilation on Windows
-  "tls"
   "yojson"
 ]
 synopsis: "Utilities for the Cryptosense API"

--- a/cs_api_client.opam
+++ b/cs_api_client.opam
@@ -3,7 +3,7 @@ maintainer: ["Cryptosense <opensource@cryptosense.com>"]
 authors: ["Cryptosense <opensource@cryptosense.com>"]
 homepage: "https://github.com/cryptosense/api-client"
 bug-reports: "https://github.com/cryptosense/api-client/issues"
-license: "BSD-2"
+license: "BSD-2-Clause"
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]

--- a/multipart-form-writer/dune
+++ b/multipart-form-writer/dune
@@ -1,5 +1,5 @@
 (library
  (name multipart_form_writer)
- (libraries lwt lwt.unix stringext terminal_size)
+ (libraries lwt lwt.unix terminal_size)
  (preprocess
   (pps lwt_ppx)))


### PR DESCRIPTION
I think we forgot to update the dependencies after we switched from Cohttp to ocurl (libcurl) for HTTP requests.