### PR TITLE
Fixes the windows-latest workflow and adds the most recent Ubuntu LTS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
+          - ubuntu-22.04
           - windows-latest
         ocaml-compiler:
           - 4.13.x
@@ -30,7 +31,6 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-repositories: |
             default: 'https://github.com/fdopen/opam-repository-mingw.git#opam2'
-            upstream: 'https://github.com/ocaml/opam-repository.git'
       - run: opam pin add cs_api_client.dev . --no-action
       - run: opam depext cs_api_client --yes --with-test
       - run: opam install . --deps-only --with-test


### PR DESCRIPTION
I couldn't really find what the `upstream` part in `ocaml-repositories` was doing there even when looking at the `setup-ocaml` GitHub action's code but it seems to be what made the `windows-latest` job fail every time.

I also added a job for Ubuntu 22.04 because it's the most recent Ubuntu LTS version.