### PR TITLE
Add commands and use the new web-findings API when possible

### DIFF
--- a/cs_api_core/cs_api_core.mli
+++ b/cs_api_core/cs_api_core.mli
@@ -2,6 +2,10 @@ module Graphql : sig
   val to_global_id : type_:string -> id:int -> string
 
   val create_trace : string
+
+  val analyze_trace : string
+
+  val list_profiles : string
 end
 
 val parse_s3_signature_request :
@@ -13,9 +17,14 @@ val parse_s3_response : body:string -> string
 val build_s3_signed_post_request : api:Api.t -> Api.Request.t
 (** Request building functions **)
 
-val build_list_projects_request : api:Api.t -> Api.Request.t
+val build_list_profiles_request : api:Api.t -> Api.Request.t
 
-val parse_list_projects_response : body:string -> (string * int) list
+val build_search_project_by_name_request :
+  api:Api.t -> name:string -> Api.Request.t
+
+val parse_list_profiles_response : body:string -> (string * int * string) list
+
+val parse_search_project_by_name_response : body:string -> int option
 
 val build_file_upload_request :
      s3_url:string
@@ -30,3 +39,10 @@ val build_trace_import_request :
   -> trace_name:string
   -> file:Api.File.t
   -> Api.Request.t
+
+val build_analyze_request :
+  api:Api.t -> trace_id:int -> profile_id:int -> Api.Request.t
+
+val get_id_from_trace_import_response_body : body:string -> int
+
+val get_info_from_analyze_response_body : body:string -> string * int

--- a/test/test.ml
+++ b/test/test.ml
@@ -59,7 +59,39 @@ let request_builder_tests =
                          ; ("size", `Int 10) ] ) ])) }
       ~actual:
         (Cs_api_core.build_trace_import_request ~api ~project_id:9 ~s3_key:"abc"
-           ~trace_name:"cde" ~file:{path = "path"; size = 10}) ]
+           ~trace_name:"cde" ~file:{path = "path"; size = 10})
+  ; test_request ~name:"Trace analysis request"
+      ~expected:
+        { url = "endpoint/api/v2"
+        ; header = [("API-KEY", "KEY"); ("Content-Type", "application/json")]
+        ; method_ = Post
+        ; data =
+            Raw
+              (Yojson.Safe.to_string
+                 (`Assoc
+                   [ ("query", `String Cs_api_core.Graphql.analyze_trace)
+                   ; ( "variables"
+                     , `Assoc
+                         [ ( "traceId"
+                           , `String
+                               (Cs_api_core.Graphql.to_global_id ~type_:"Trace"
+                                  ~id:9) )
+                         ; ( "profileId"
+                           , `String
+                               (Cs_api_core.Graphql.to_global_id
+                                  ~type_:"Profile" ~id:2) ) ] ) ])) }
+      ~actual:(Cs_api_core.build_analyze_request ~api ~trace_id:9 ~profile_id:2)
+  ; test_request ~name:"List profiles request"
+      ~expected:
+        { Api.Request.url = "endpoint/api/v2"
+        ; header = [("API-KEY", "KEY"); ("Content-Type", "application/json")]
+        ; method_ = Post
+        ; data =
+            Raw
+              (Yojson.Safe.to_string
+                 (`Assoc [("query", `String Cs_api_core.Graphql.list_profiles)]))
+        }
+      ~actual:(Cs_api_core.build_list_profiles_request ~api) ]
 
 let () =
   Alcotest.run "API Client"


### PR DESCRIPTION
First, when a project name is supplied to upload a trace, this uses the new API just added: it asks `web-findings` for a project with this exact name to get its ID instead of asking for a list of all existing project, then searching for the name inside of it.

This also adds two commands:
- `list-profiles` to print a list of all profiles (useful for the other command)
- `analyze` to analyze an already uploaded & processed trace (using its ID)

Analyzing a given trace is not a problem because, now, the `upload-trace` command is giving the ID of the newly uploaded trace back.

An `--analyze {profile ID}` option is also added to `upload-trace` command to instantly analyze the trace when it's uploaded.
I'm not a fan of how this is implemented: since there's now way, for the moment, to know when a trace has been correctly processed, this option just makes the program wait for 5 seconds before sending a request to analyze using the API and, if the answer that the trace has not been processed yet, wait 5 seconds again (...) until the answer is either another error or the response is that the report is being processed. I chose 5 seconds because I want to limit the number of requests sent to the server and, locally, even 5 seconds wasn't enough sometimes.

This could theoretically be a problem because it's possible for a trace to stay in the `TracePending` state but I don't think it would actually happen in real life (I've only seen this problem locally, when there was an error in the code?). An easy way to avoid this would of course be to add a limit on the number of tries.
EDIT: A counter mechanism has been added (5 times max, 5 second wait). There's no counter for the `analyze` command but I could actually let it try one more time instead of  failing  instantly?

I'll be happy if someone finds a more elegant/better way to implement this option.