### PR TITLE
Add slot name option

### DIFF
--- a/cs_api_cli/cs_api_cli.ml
+++ b/cs_api_cli/cs_api_cli.ml
@@ -61,6 +61,7 @@ let upload_trace
     ~trace_name
     ~project_id
     ~project_name
+    ~slot_name
     ~analyze
     ~api =
   let open Lwt.Infix in
@@ -85,8 +86,8 @@ let upload_trace
   >>= (fun body ->
         let s3_key = Cs_api_core.parse_s3_response ~body in
         let import_request =
-          Cs_api_core.build_trace_import_request ~api ~project_id ~s3_key
-            ~trace_name ~file
+          Cs_api_core.build_trace_import_request ~slot_name ~api ~project_id
+            ~s3_key ~trace_name ~file
         in
         Lwt.return (Ok import_request))
   >>= Cs_api_io.send_request ~client
@@ -145,6 +146,13 @@ let project_id =
      with --project-name."
   in
   Cmdliner.Arg.(value & opt (some int) None & info ["p"; "project-id"] ~doc)
+
+let slot_name =
+  let doc =
+    "Name of the slot the trace should be added to. If no slot with this name \
+     exist in the chosen project then one will be created."
+  in
+  Cmdliner.Arg.(value & opt (some string) None & info ["slot-name"] ~doc)
 
 let project_name =
   let doc =
@@ -218,12 +226,14 @@ let upload_trace_main
     trace_name
     project_id
     project_name
+    slot_name
     analyze
     api_endpoint
     api_key
     ca_file
     no_check_certificate =
-  upload_trace ~trace_file ~trace_name ~project_id ~project_name ~analyze
+  upload_trace ~trace_file ~trace_name ~project_id ~project_name ~slot_name
+    ~analyze
   |> run_command ~ca_file ~no_check_certificate ~api_endpoint ~api_key
 
 let analyze_trace_main
@@ -276,6 +286,7 @@ let upload_trace_term =
     $ trace_name
     $ project_id
     $ project_name
+    $ slot_name
     $ analyze
     $ api_endpoint
     $ api_key

--- a/cs_api_core/cs_api_core.mli
+++ b/cs_api_core/cs_api_core.mli
@@ -1,6 +1,8 @@
 module Graphql : sig
   val to_global_id : type_:string -> id:int -> string
 
+  val generate_trace_upload_post : string
+
   val create_trace : string
 
   val analyze_trace : string
@@ -35,6 +37,7 @@ val build_file_upload_request :
 val build_trace_import_request :
      api:Api.t
   -> project_id:int
+  -> slot_name:string option
   -> s3_key:string
   -> trace_name:string
   -> file:Api.File.t


### PR DESCRIPTION
Two changes:
- Now uses v2 instead of v1 API. It had been disabled for a while now...
- Adds a `--slot-name` option to the upload trace command to be able to choose the name of the (existing or not) slot the trace will be uploaded to.