### PR TITLE
Add compatibility with seaweedfs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Retrieve new lists of system packages
         if: runner.os != 'Windows'
         run: sudo apt-get update
@@ -38,4 +38,13 @@ jobs:
       - run: opam pin add cs_api_client.dev . --no-action
       - run: opam depext cs_api_client --yes --with-test
       - run: opam install . --deps-only --with-test
+      - name: Tag substitution
+        run: bash ./ci/subst.bash "${{ github.ref_name }}"
+        if: startsWith(github.ref, 'refs/tags/')
       - run: opam exec -- dune build @all @fmt @runtest
+      - name: Upload compiled binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cs-api-${{ matrix.os }}
+          path: _build/install/default/bin/*
+          if-no-files-found: error

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 _There are no unreleased changes at the moment._
 
+## [2.5.1] - 2023-11-08
+
+### Fixed
+
+* Fix compatibility with SeaweedFS API responses
+
 ## [2.5.0] - 2023-10-19
 
 ### Fixed

--- a/cs_api_core/cs_api_core.ml
+++ b/cs_api_core/cs_api_core.ml
@@ -191,7 +191,7 @@ let parse_s3_signature_request ~body =
 
 let parse_s3_response ~body =
   try
-    let key_extractor = Str.regexp "<Key>\\([^<>]*\\)</Key>" in
+    let key_extractor = Str.regexp "<.*Key>\\([^<>]*\\)</.*Key>" in
     let _ = Str.search_forward key_extractor body 0 in
     Ok (Str.matched_group 1 body)
   with

--- a/cs_api_core/cs_api_core.ml
+++ b/cs_api_core/cs_api_core.ml
@@ -191,7 +191,7 @@ let parse_s3_signature_request ~body =
 
 let parse_s3_response ~body =
   try
-    let key_extractor = Str.regexp "<.*Key.*>\\([^<>]*\\)</.*Key.*>" in
+    let key_extractor = Str.regexp "<Key.*>\\([^<>]*\\)</Key>" in
     let _ = Str.search_forward key_extractor body 0 in
     Ok (Str.matched_group 1 body)
   with

--- a/cs_api_core/cs_api_core.ml
+++ b/cs_api_core/cs_api_core.ml
@@ -191,7 +191,7 @@ let parse_s3_signature_request ~body =
 
 let parse_s3_response ~body =
   try
-    let key_extractor = Str.regexp "<.*Key>\\([^<>]*\\)</.*Key>" in
+    let key_extractor = Str.regexp "<.*Key.*>\\([^<>]*\\)</.*Key.*>" in
     let _ = Str.search_forward key_extractor body 0 in
     Ok (Str.matched_group 1 body)
   with

--- a/test/test_key_extractor.ml
+++ b/test/test_key_extractor.ml
@@ -24,5 +24,12 @@ let tests =
 <PostResponse><Bucket>cryptosense-traces</Bucket><Key>uploads/784f2aa928404db3a958fbd779a44156</Key><ETag>&#34;82887f4dd13a80e182aa01efc0a59e9e&#34;</ETag><Location>http://localhost:9000/cryptosense-traces/uploads/784f2aa928404db3a958fbd779a44156</Location></PostResponse>
     |}
       ~expected:(Ok "uploads/784f2aa928404db3a958fbd779a44156")
+  ; test_body ~name:"Valid SeaweedFS body"
+      ~body:
+        {|
+<?xml version="1.0" encoding="UTF-8"?>
+<PostResponse><Bucket>cryptosense-traces</Bucket><xmlns:Key>uploads/784f2aa928404db3a958fbd779a44156</xmlns:Key><ETag>&#34;82887f4dd13a80e182aa01efc0a59e9e&#34;</ETag><Location>http://localhost:9000/cryptosense-traces/uploads/784f2aa928404db3a958fbd779a44156</Location></PostResponse>
+    |}
+      ~expected:(Ok "uploads/784f2aa928404db3a958fbd779a44156")
   ; test_body ~name:"Invalid body" ~body:"This\ndoes not\ncontain a key."
       ~expected:(Error "Key could not be extracted from S3 response.") ]

--- a/test/test_key_extractor.ml
+++ b/test/test_key_extractor.ml
@@ -28,8 +28,8 @@ let tests =
       ~body:
         {|
 <?xml version="1.0" encoding="UTF-8"?>
-<PostResponse><Bucket>cryptosense-traces</Bucket><xmlns:Key>uploads/784f2aa928404db3a958fbd779a44156</xmlns:Key><ETag>&#34;82887f4dd13a80e182aa01efc0a59e9e&#34;</ETag><Location>http://localhost:9000/cryptosense-traces/uploads/784f2aa928404db3a958fbd779a44156</Location></PostResponse>
+<PostResponse><Location xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></Location><Bucket xmlns="http://s3.amazonaws.com/doc/2006-03-01/">storage-traces</Bucket><Key xmlns="http://s3.amazonaws.com/doc/2006-03-01/">uploads/48db212785054589966f84565a263e90</Key><ETag xmlns="http://s3.amazonaws.com/doc/2006-03-01/">&#34;4425e01772cfdca990eff5f085d05414&#34;</ETag></PostResponse>
     |}
-      ~expected:(Ok "uploads/784f2aa928404db3a958fbd779a44156")
+      ~expected:(Ok "uploads/48db212785054589966f84565a263e90")
   ; test_body ~name:"Invalid body" ~body:"This\ndoes not\ncontain a key."
       ~expected:(Error "Key could not be extracted from S3 response.") ]


### PR DESCRIPTION
Expand the regex parser to allow for a namespace in front of the key tag.