### PR TITLE
Enable the user to select a directory instead of a file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-_There are no unreleased changes at the moment._
+### Added
+
+* Add the ability for `--filename` to accept a directory. The client will upload the file
+  in that directory only if it contains a single file.
+* Add more details to error messages if the client fails to read a directory or trace file.
 
 ## [2.5.2] - 2024-04-16
 

--- a/cs_api_cli/dune
+++ b/cs_api_cli/dune
@@ -1,4 +1,6 @@
 (executable
  (public_name cs-api)
  (name cs_api_cli)
- (libraries cmdliner cs_api_io cs_api_core))
+ (libraries cmdliner cs_api_io cs_api_core)
+ (preprocess
+  (pps lwt_ppx)))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.7)
+(cram enable)
 (name cs_api_client)

--- a/integration_test/connection_error.t
+++ b/integration_test/connection_error.t
@@ -1,0 +1,14 @@
+Create a trace directory with no permissions:
+
+  $ touch trace-file
+
+Try to upload traces from that directory:
+
+  $ cs-api upload-trace \
+  >     --api-base-url localhost:1 \
+  >     --project-id 1 \
+  >     --slot-name slot-0 \
+  >     --trace-name trace-0 \
+  >     --trace-file trace-file \
+  > | sed 's/\(HTTP error (CURLE_COULDNT_CONNECT):\).*/\1 <redacted>/'  # Redact the platform-dependent part of the message.
+  HTTP error (CURLE_COULDNT_CONNECT): <redacted>

--- a/integration_test/dune
+++ b/integration_test/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps %{bin:cs-api}))

--- a/integration_test/empty_dir.t
+++ b/integration_test/empty_dir.t
@@ -1,0 +1,14 @@
+Create a empty trace directory:
+
+  $ mkdir trace-dir
+
+Try to upload traces from that directory:
+
+  $ cs-api upload-trace \
+  >     --api-base-url localhost:1234 \
+  >     --project-id 1 \
+  >     --slot-name slot-0 \
+  >     --trace-name trace-0 \
+  >     --trace-file trace-dir
+  Empty directory: trace-dir
+  [1]

--- a/integration_test/missing_subcommand.t
+++ b/integration_test/missing_subcommand.t
@@ -1,0 +1,7 @@
+Execute the command without a subcommand:
+
+  $ cs-api
+  cs-api: Missing command
+  Usage: cs-api [COMMAND] …
+  Try 'cs-api --help' for more information.
+  [124]

--- a/integration_test/multiple_files_in_dir.t
+++ b/integration_test/multiple_files_in_dir.t
@@ -1,0 +1,17 @@
+Create a trace directory with multiple files in it:
+
+  $ mkdir trace-dir
+  $ touch trace-dir/trace-0 trace-dir/trace-1
+
+Try to upload traces from that directory:
+
+  $ cs-api upload-trace \
+  >     --api-base-url localhost:1234 \
+  >     --project-id 1 \
+  >     --slot-name slot-0 \
+  >     --trace-name trace-0 \
+  >     --trace-file trace-dir
+  Found trace file: trace-0
+  Found trace file: trace-1
+  More than one file found in directory: trace-dir
+  [1]

--- a/integration_test/permission_denied.t
+++ b/integration_test/permission_denied.t
@@ -1,0 +1,19 @@
+Create a trace directory with no permissions:
+
+  $ mkdir trace-dir
+  $ chmod 000 trace-dir
+
+Try to upload traces from that directory:
+
+  $ cs-api upload-trace \
+  >     --api-base-url localhost:1234 \
+  >     --project-id 1 \
+  >     --slot-name slot-0 \
+  >     --trace-name trace-0 \
+  >     --trace-file trace-dir
+  Permission denied for path: trace-dir
+  [1]
+
+Restore the permissions on the directory so that Dune can clean up the test directory:
+
+  $ chmod 755 trace-dir


### PR DESCRIPTION
Changes for the user (see also the changelog):

- `--filename` accepts a directory containing just one file.
- More detailed error messages.

Internal changes:

- Added Cram tests in Dune to check the behavior of `cs-api` on cases that don't involve actual upload (since we don't have a test server or dry-run mode).
  - We can probably add more cases later; this is just a start.
  - I think those specific tests don't run on Windows at the moment; not sure why but we may want to fix that later.