### PR TITLE
Make `--trace-name` optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in that directory only if it contains a single file.
 * Add more details to error messages if the client fails to read a directory or trace file.
 
+### Changed
+
+* Make `--trace-name` optional. If not provided, the server will pick the name for the
+  newly uploaded trace. This is useful because trace names must be unique within a project
+  on the server, and users may not know what names are already taken.
+
 ## [2.5.2] - 2024-04-16
 
 ### Fixed

--- a/cs_api_cli/cs_api_cli.ml
+++ b/cs_api_cli/cs_api_cli.ml
@@ -198,9 +198,12 @@ let trace_id =
   Cmdliner.Arg.(required & opt (some int) None & info ["trace-id"] ~doc)
 
 let trace_name =
-  let doc = "Name of the trace" in
+  let doc =
+    "Name of the trace to use in the server. If not provided, the server will \
+     pick the name."
+  in
   Cmdliner.Arg.(
-    required
+    value
     & opt (some string) None
     & info ["n"; "trace-name"] ~docv:"TRACENAME" ~doc)
 

--- a/cs_api_core/cs_api_core.ml
+++ b/cs_api_core/cs_api_core.ml
@@ -253,6 +253,11 @@ let build_trace_import_request
     | Some name -> `String name
     | None -> `Null
   in
+  let trace_name_var =
+    match trace_name with
+    | Some name -> `String name
+    | None -> `Null
+  in
   { Api.Request.url = endpoint ^ "/api/v2"
   ; header = [("API-KEY", key); ("Content-Type", "application/json")]
   ; method_ = Post
@@ -268,7 +273,7 @@ let build_trace_import_request
                      , `String
                          (Graphql.to_global_id ~type_:"Project" ~id:project_id)
                      )
-                   ; ("name", `String trace_name)
+                   ; ("name", trace_name_var)
                    ; ("key", `String s3_key)
                    ; ("size", `Int size) ] ) ])) }
 

--- a/cs_api_core/cs_api_core.mli
+++ b/cs_api_core/cs_api_core.mli
@@ -36,7 +36,7 @@ val build_trace_import_request :
   -> project_id:int
   -> slot_name:string option
   -> s3_key:string
-  -> trace_name:string
+  -> trace_name:string option
   -> file:Api.File.t
   -> Api.Request.t
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -57,6 +57,30 @@ let request_builder_tests =
            ~s3_method:Api.Method.Put
            ~s3_signature:[("key", "abc"); ("signature", "cde")]
            ~file:{path = "folder/path"; size = 10})
+  ; test_request ~name:"Trace import request without trace name"
+      ~expected:
+        { url = "endpoint/api/v2"
+        ; header = [("API-KEY", "KEY"); ("Content-Type", "application/json")]
+        ; method_ = Post
+        ; data =
+            Raw
+              (Yojson.Safe.to_string
+                 (`Assoc
+                   [ ("query", `String Cs_api_core.Graphql.create_trace)
+                   ; ( "variables"
+                     , `Assoc
+                         [ ("slotName", `Null)
+                         ; ( "projectId"
+                           , `String
+                               (Cs_api_core.Graphql.to_global_id
+                                  ~type_:"Project" ~id:9) )
+                         ; ("name", `Null)
+                         ; ("key", `String "abc")
+                         ; ("size", `Int 10) ] ) ])) }
+      ~actual:
+        (Cs_api_core.build_trace_import_request ~api ~project_id:9
+           ~slot_name:None ~s3_key:"abc" ~trace_name:None
+           ~file:{path = "path"; size = 10})
   ; test_request ~name:"Trace import request without slot name"
       ~expected:
         { url = "endpoint/api/v2"
@@ -79,7 +103,7 @@ let request_builder_tests =
                          ; ("size", `Int 10) ] ) ])) }
       ~actual:
         (Cs_api_core.build_trace_import_request ~api ~project_id:9
-           ~slot_name:None ~s3_key:"abc" ~trace_name:"cde"
+           ~slot_name:None ~s3_key:"abc" ~trace_name:(Some "cde")
            ~file:{path = "path"; size = 10})
   ; test_request ~name:"Trace import request with slot name"
       ~expected:
@@ -103,7 +127,7 @@ let request_builder_tests =
                          ; ("size", `Int 10) ] ) ])) }
       ~actual:
         (Cs_api_core.build_trace_import_request ~api ~project_id:9
-           ~slot_name:(Some "name") ~s3_key:"abc" ~trace_name:"cde"
+           ~slot_name:(Some "name") ~s3_key:"abc" ~trace_name:(Some "cde")
            ~file:{path = "path"; size = 10})
   ; test_request ~name:"Trace analysis request"
       ~expected:


### PR DESCRIPTION
Changes for the user:

- Make `--trace-name` optional. If not provided, the server will pick the name for the newly uploaded trace. This is useful because trace names must be unique within a project on the server, and users may not know what names are already taken.