### PR TITLE
Use Opam 2.2 on Windows (via setup-ocaml@v3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,19 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
       - name: Set up OCaml
-        # We can't use setup-ocaml@v3 yet because ocurl can't be installed with it for now
-        # (curl-config issue).
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.14.x
           opam-repositories: |
-            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+            local: opam_win_repo
             default: https://github.com/ocaml/opam-repository.git
       - name: Set build version
         id: build_version
+        shell: bash
+        env:
+          SHELLOPTS: igncr
         run: |
-          echo "value=$(bash ci/get_version.bash "${{ github.ref_type }}" "${{ github.ref_name }}")" >> $env:GITHUB_OUTPUT
+          echo "value=$(bash ci/get_version.bash "${{ github.ref_type }}" "${{ github.ref_name }}")" >> $GITHUB_OUTPUT
       - name: Using version ${{ steps.build_version.outputs.value }}
         run: |
           echo "Version number: ${{ steps.build_version.outputs.value }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .merlin
 _build
+_opam

--- a/opam_win_repo/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/opam_win_repo/packages/conf-libcurl/conf-libcurl.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Virtual package relying on a libcurl system installation"
+description:
+  "This package can only install if the libcurl is installed on the system."
+maintainer: "blue-prawn"
+authors: "Daniel Stenberg"
+license: "BSD-like"
+homepage: "http://curl.haxx.se/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+build: [
+  ["pkgconf" {os = "win32" & os-distribution = "cygwin"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution != "cygwin"}
+   "--print-errors" "--exists" "libcurl"]
+]
+depends: [
+  "conf-pkg-config" {build}
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
+depexts: [
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
+  ["libcurl4-gnutls-dev"] {os-family = "ubuntu"}
+  ["libcurl-devel"] {os-distribution = "mageia"}
+  ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
+  ["curl"] {os-distribution = "nixos"}
+  ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
+  ["curl-dev"] {os-distribution = "alpine"}
+  ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libcurl-devel"] {os-distribution = "fedora"}
+  ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
+  ["curl"] {os = "freebsd"}
+]

--- a/opam_win_repo/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
+++ b/opam_win_repo/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis: "libcurl for x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of libcurl for the mingw-w64 project is available"
+maintainer: "David Allsopp <david@tarides.com>"
+authors: "The OpenSSL Project"
+license: "Apache-1.0"
+homepage: "https://curl.se"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+available: os = "win32" & os-distribution = "cygwin"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libcurl"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
+depexts: [
+  ["mingw64-x86_64-curl"] {os = "win32" & os-distribution = "cygwin"}
+  ["mingw-w64-x86_64-curl"] {os = "win32" & os-distribution = "msys2"}
+]

--- a/opam_win_repo/packages/ocurl/ocurl.0.9.1/opam
+++ b/opam_win_repo/packages/ocurl/ocurl.0.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+homepage: "https://ygrek.org/p/ocurl"
+license: "MIT"
+authors: [ "Lars Nilsson" "ygrek" ]
+doc: ["https://ygrek.org/p/ocurl/api/index.html"]
+dev-repo: "git+https://github.com/ygrek/ocurl.git"
+bug-reports: "https://github.com/ygrek/ocurl/issues"
+tags: ["org:ygrek" "clib:curl"]
+build-env: [  # Hack to fix the environment for Windows x64
+  [PKG_CONFIG_PATH = "/usr/x86_64-w64-mingw32/sys-root/mingw/lib/pkgconfig"]
+  [CC = "/usr/bin/x86_64-w64-mingw32-gcc.exe"]
+]
+build: [
+  ["./configure"]
+  [make]
+  [make "doc"] {with-doc}
+  [make "test"] {with-test & ocaml:version < "5.0.0"}
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "ocamlfind" {build}
+  "base-unix"
+  "conf-libcurl"
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+depopts: ["lwt" "lwt_ppx"]
+synopsis: "Bindings to libcurl"
+description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."
+url {
+  src: "https://ygrek.org/p/release/ocurl/ocurl-0.9.1.tar.gz"
+  checksum: [
+    "md5=1ff6b12803fa0c6e9a4358dd29b83910"
+    "sha256=c65f01913270b674a0ca0f278f91bc1e368d7110e8308084bc2280b43a0bc258"
+    "sha512=1ec21065f67ac227efb071ad696648ab4ac488ce77db091b4f212821b863fdcb2b23b6b9d579e8878fe8f1a6b2f0ec81c2751a72a1df201ea47f016012107429"
+  ]
+  mirrors: "https://github.com/ygrek/ocurl/releases/download/0.9.1/ocurl-0.9.1.tar.gz"
+}

--- a/opam_win_repo/repo
+++ b/opam_win_repo/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"


### PR DESCRIPTION
This upgrades the OCaml action used in CI, so that we use the same Opam as for Linux and get the same benefits.

The only downside is that we have to fix some package definitions, hence the custom `opam_win_repo` repository. Hopefully this is temporary and won't be necessary for long (once the official repository will have caught up).