### PR TITLE
Fix a bug preventing trace upload without `--trace-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
 - Fix a bug which would prevent upload from working on Windows (an error would be returned
   by the client).
+- Fix an API server error when `--filename` is absent.
 
 ## [2.6.0] - 2024-07-24
 

--- a/cs_api_core/cs_api_core.mli
+++ b/cs_api_core/cs_api_core.mli
@@ -1,7 +1,17 @@
 module Graphql : sig
   val to_global_id : type_:string -> id:int -> string
   val generate_trace_upload_post : string
+
   val create_trace : string
+  (** Mutation to register a trace (the upload of which has finished). *)
+
+  val create_trace_no_name : string
+  (** Same as [create_trace] but without a `name` parameter.
+
+      It is needed because of a bug in the GraphQL API with [`Null] values. Once this is
+      resolved, this query can be removed and the [create_trace] query will be able to use
+      a [`Null] value for its [name] parameter. *)
+
   val analyze_trace : string
   val list_profiles : string
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -66,7 +66,7 @@ let request_builder_tests =
             Raw
               (Yojson.Safe.to_string
                  (`Assoc
-                   [ ("query", `String Cs_api_core.Graphql.create_trace)
+                   [ ("query", `String Cs_api_core.Graphql.create_trace_no_name)
                    ; ( "variables"
                      , `Assoc
                          [ ("slotName", `Null)

--- a/test_end_to_end/test_upload.py
+++ b/test_end_to_end/test_upload.py
@@ -4,13 +4,10 @@ import secrets
 import subprocess
 from pathlib import Path
 
-import pytest
-
 from . import util
 from .conftest import Server
 
 
-@pytest.mark.xfail(reason="Known bug when `--trace-name` is absent")
 def test_upload_file(executable: str, server: Server, tmp_path: Path) -> None:
     trace_file = tmp_path / "trace.cst.gz"
 


### PR DESCRIPTION
Changes for the user:

- Fix a bug preventing trace upload without `--trace-name`. The client was previously making an invalid request which resulted in nothing being uploaded.