### PR TITLE
Fix default API base URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- The default value of `--api-base-url` is changed to
+  `https://aqtiveguard.cryptosense.com`. The former value caused the client to exit early
+  with an HTTP 308 response code (permanent redirect).
 - Fix a bug which would prevent upload from working on Windows (an error would be returned
   by the client).
 - Fix an API server error when `--filename` is absent.

--- a/README.md
+++ b/README.md
@@ -11,32 +11,28 @@ The Cryptosense API Client depends on libcurl.
 ```bash
 $ export CRYPTOSENSE_API_KEY=secret
 $ ./cs-api upload-trace \
+    --verbose \
+    --trace-file test_trace.cst.gz \
     --project-id 1 \
-    --trace-name 'Test trace' \
-    --trace-file test_trace.cst.gz
-Request: POST https://analyzer.cryptosense.com/api/v1/trace_s3_post
-Request: POST https://analyzer.cryptosense.com/api/v1/trace_s3_post
-Request: POST https://analyzer.cryptosense.com/storage-traces
-[=====================================================================================] 100.00%
-Request: POST https://analyzer.cryptosense.com/api/v1/projects/1/traces
-Trace imported
+    --analyze 1
+DEBUG    HTTP request: POST https://aqtiveguard.sandboxaq.com/api/v2
+DEBUG    HTTP response: 200
+DEBUG    HTTP request: POST https://storage.googleapis.com/cs-prod-traces
+DEBUG    HTTP response: 201
+DEBUG    HTTP request: POST https://aqtiveguard.sandboxaq.com/api/v2
+DEBUG    HTTP response: 200
+INFO     Trace 1234 uploaded
+DEBUG    HTTP request: POST https://aqtiveguard.sandboxaq.com/api/v2
+DEBUG    HTTP response: 200
+INFO     Report 'Report 1234' of ID 1234 is being generated
 ```
 
-For more information about the CLI parameters, run: `cs-api --help`.
+### Documentation
+
+- [Online documentation][public_docs]
+- For CLI usage, use `cs-api --help`.
 
 ### FAQ
-
-#### How to find the ID of my project?
-
-In the web interface, select your project by clicking it and copy the number after
-`/projects/` in the URL.
-
-#### How to upload to a local instance of Cryptosense Analyzer?
-
-Use the `--api-base-url` parameter to point the CLI at your local instance.
-
-If you are using self-signed certificates or a custom CA, you can provide a custom CA file
-with the `--ca-file path/to/cabundle.pem` option.
 
 #### HTTP Proxies
 
@@ -156,3 +152,4 @@ slot_name = "cs-api-test"
 [github_actions]: https://github.com/cryptosense/api-client/actions
 [github_actions_main]: https://github.com/cryptosense/api-client/actions?query=branch%3Amain
 [github_status_badge]: https://github.com/cryptosense/api-client/actions/workflows/main.yml/badge.svg?branch=main
+[public_docs]: https://aqtiveguard.sandboxaq.com/docs/api/api-client/

--- a/cs_api_cli/cs_api_cli.ml
+++ b/cs_api_cli/cs_api_cli.ml
@@ -251,7 +251,7 @@ let api_endpoint =
   let doc = "Base URL of the API server." in
   Cmdliner.Arg.(
     value
-    & opt string "https://analyzer.cryptosense.com"
+    & opt string "https://aqtiveguard.sandboxaq.com"
     & info ["u"; "api-base-url"] ~docv:"BASE_URL" ~doc)
 
 let api_key =

--- a/test_end_to_end/conftest.py
+++ b/test_end_to_end/conftest.py
@@ -11,6 +11,7 @@ import tomllib
 class Server:
     api_key: str
     api_url: str
+    is_default_url: bool
     trusted_cert: bool
     ca_path: str | None
     project_id: int
@@ -43,6 +44,7 @@ def parse_config(config_dict: Mapping[str, Any], path: str) -> Server:
         return Server(
             api_key=config_dict["api_key"],
             api_url=config_dict["api_url"],
+            is_default_url=config_dict["is_default_url"],
             trusted_cert=config_dict["trusted_cert"],
             ca_path=config_dict.get("ca_path"),
             profile_id=config_dict["profile_id"],


### PR DESCRIPTION
Changes for the user:

- The default API base URL is changed to https://aqtiveguard.sandboxaq.com. This fixes the use of the client with the default URL, because otherwise the client would exit early because of a 308 (permanent redirect) response code.

Internal changes:

- The readme is updated with more accurate information.