### PR TITLE
Bundle libcurl for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,18 @@ jobs:
         run: |
           New-Item -ItemType Directory -ErrorAction SilentlyContinue build/cs-api-${{ steps.build_version.outputs.value }}-windows
           Copy-Item _build/install/default/bin/cs-api.exe build/cs-api-${{ steps.build_version.outputs.value }}-windows/
+      - name: Download and bundle libcurl
+        shell: bash
+        env:
+          SHELLOPTS: igncr
+        run: |
+          bash ci/static-dl \
+            --url https://curl.se/windows/dl-8.9.1_1/curl-8.9.1_1-win64-mingw.zip \
+            --hash f7bc9e21490d942c937dfe7bfcb9a2e29a490665c8b51e8ea0cdc171ac08c5de \
+            --out /tmp/curl.zip
+          mkdir /tmp/curl
+          unzip -q /tmp/curl.zip -d /tmp/curl
+          cp /tmp/curl/*/bin/libcurl-x64.dll build/cs-api-${{ steps.build_version.outputs.value }}-windows/libcurl-4.dll
       - name: Upload the compiled binary
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-_There are no unreleased changes at the moment._
+### Added
+
+- The Windows release now ships with `libcurl-4.dll` (from https://curl.se/windows/).
 
 ## [2.7.0] - 2024-08-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
 USER "$user"
 
 # Add script for downloading files
-COPY --chown="$user:$user" docker/static-dl /usr/local/bin/static-dl
+COPY --chown="$user:$user" ci/static-dl /usr/local/bin/static-dl
 RUN chmod +x /usr/local/bin/static-dl
 
 RUN mkdir "/home/$user/workdir"

--- a/ci/static-dl
+++ b/ci/static-dl
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Download a file with `wget` and check its SHA-256 hash.
+# Download a file with `curl` or `wget` and check its SHA-256 hash.
 #
 # To download with a hash check:
 #
@@ -24,9 +24,22 @@ show_hash_and_fail() {
     local url=$1; shift
     local file=$1; shift
 
-    local hash=$(sha256sum "$file" | cut -f 1 -d " ")
+    local hash
+    hash=$(sha256sum "$file" | cut -f 1 -d " ")
     echo "Actual hash for $url: $hash" >&2
     return 1
+}
+
+download() {
+    local url=$1; shift
+    local out=$1; shift
+
+    # If curl is found, use it, otherwise use wget.
+    if command -v curl > /dev/null; then
+        curl --location --output "$out" "$url"
+    else
+        wget --output-document "$out" "$url"
+    fi
 }
 
 main() {
@@ -34,10 +47,11 @@ main() {
     local hash_=$1; shift
     local out=$1; shift
 
-    local tmp_dir=$(mktemp --directory)
+    local tmp_dir
+    tmp_dir=$(mktemp --directory)
     local tmp_file="$tmp_dir/downloaded"
 
-    wget -nv -O "$tmp_file" "$url"
+    download "$url" "$tmp_file"
     echo "$hash_ $tmp_file" | sha256sum --check --strict \
         || show_hash_and_fail "$url" "$tmp_file"
 


### PR DESCRIPTION
Changes for the user:

- The Windows release now ships with `libcurl-4.dll` (from https://curl.se/windows/).

Other comments:

- The download script was adjusted to use `curl` when it's available instead of `wget`. The latter was problematic on Windows; I couldn't get it to work with a specific output file (with `-O`).
- I applied shellcheck recommendations to the download script.