### PR TITLE
Add support for testing on CentOS 8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 **/*.pyc
 **/.merlin
+**/.mypy_cache
+**/.venv
 **/__pycache__
 **/_build
 **/_opam

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           build-args: |
-            OPAM_BASE=opam-centos-7
+            CENTOS_BASE=centos:7
+            OPAM_BASE=opam-centos-based
             OCAML_VERSION=4.14.2
             VERSION=${{ steps.build_version.outputs.value }}
           target: main

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 .dmypy.json
 .merlin
+.mypy_cache
+.venv
 __pycache__
 _build
 _opam


### PR DESCRIPTION
Changes for the user: none.

Internal changes: As developers we can now use CentOS 8 as a base Docker image.