### PR TITLE
Release version 2.7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
           mkdir /tmp/curl
           unzip -q /tmp/curl.zip -d /tmp/curl
           cp /tmp/curl/*/bin/libcurl-x64.dll build/cs-api-${{ steps.build_version.outputs.value }}-windows/libcurl-4.dll
+          cp /tmp/curl/*/bin/curl-ca-bundle.crt build/cs-api-${{ steps.build_version.outputs.value }}-windows/curl-ca-bundle.crt
       - name: Upload the compiled binary
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+_There are no unreleased changes at the moment._
+
+## [2.7.1] - 2024-08-21
+
 ### Added
 
-- The Windows release now ships with `libcurl-4.dll` (from https://curl.se/windows/).
+- The Windows release now ships with `libcurl-4.dll` (from https://curl.se/windows/) and a
+  CA certificates bundle.
 
 ## [2.7.0] - 2024-08-02
 
@@ -151,7 +156,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[Unreleased]: https://github.com/cryptosense/api-client/compare/2.7.0..HEAD
+[Unreleased]: https://github.com/cryptosense/api-client/compare/2.7.1..HEAD
+[2.7.1]: https://github.com/cryptosense/api-client/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/cryptosense/api-client/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/cryptosense/api-client/compare/2.5.1...2.6.0
 [2.5.2]: https://github.com/cryptosense/api-client/compare/2.5.1...2.5.2


### PR DESCRIPTION
Changes for the user:

- The Windows release ships with a CA certificates bundle.

Comments:

This is needed because on Windows we can't rely on Schannel and seem to be using OpenSSL instead. To help the user get started we provide a CA bundle they can use to get started. They will probably need to adjust it if they have custom certificates.

In the future, it might make sense to try and upgrade `ocurl` to be able to use more options of libcurl and try to make it use Schannel, and determine whether we need to compile the DLL ourselves instead of downloading it from the official website. Currently this is definitely tricky because we can't use the new ocurl on CentOS 7, and using 8+ would unnecessarily decrease the compatibility of our uploader.